### PR TITLE
Fix for search engine selection in admin. 

### DIFF
--- a/code/Model/System/Config/Source/Engine.php
+++ b/code/Model/System/Config/Source/Engine.php
@@ -2,7 +2,21 @@
 /**
  * Source model for algolia search engine
  */
-class Algolia_Algoliasearch_Model_System_Config_Source_Engine
+
+/*
+ * The class Enterprise_Search_Model_Adminhtml_System_Config_Source_Engine must be extended to access it's options array
+ * if it exists.
+ */
+if(!Mage::helper("core")->isModuleEnabled("Enterprise_Search")) {
+    class Enterprise_Search_Model_Adminhtml_System_Config_Source_Engine {
+        function toOptionArray() {
+            return array();
+        }
+    }
+}
+
+
+class Algolia_Algoliasearch_Model_System_Config_Source_Engine extends Enterprise_Search_Model_Adminhtml_System_Config_Source_Engine
 {
     public function toOptionArray()
     {
@@ -10,12 +24,12 @@ class Algolia_Algoliasearch_Model_System_Config_Source_Engine
         if (is_null($options)) {
             $options = array();
             // Retrieve options from Magento Enterprise edition
-            if (Mage::helper('core')->isModuleEnabled('Enterprise_Search')) {
-                $options = Mage::getSingleton('enterprise_search/adminhtml_system_config_source_engine')->toOptionArray();
+            if (Mage::helper("core")->isModuleEnabled("Enterprise_Search")) {
+                $options = parent::toOptionArray();
             } else {
-                $options[] = array('value' => 'catalogsearch/fulltext_engine', 'label' => Mage::helper('catalogsearch')->__('MySql Fulltext'));
+                $options[] = array("value" => "catalogsearch/fulltext_engine", "label" => Mage::helper("catalogsearch")->__("MySql Fulltext"));
             }
-            $options[] = array('value' => 'algoliasearch/engine', 'label' => Mage::helper('algoliasearch')->__('Algolia'));
+            $options[] = array("value" => "algoliasearch/engine", "label" => Mage::helper("algoliasearch")->__("Algolia"));
         }
         return $options;
     }

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -59,6 +59,16 @@
                     <fulltext>Algolia_Algoliasearch_Model_Resource_Fulltext</fulltext>
                 </rewrite>
             </catalogsearch_resource>
+            <enterprise_search>
+                <rewrite>
+                    <adminhtml_system_config_backend_engine>Algolia_Algoliasearch_Model_System_Config_Backend_Engine</adminhtml_system_config_backend_engine>
+                </rewrite>
+            </enterprise_search>
+            <enterprise_search>
+                <rewrite>
+                    <adminhtml_system_config_source_engine>Algolia_Algoliasearch_Model_System_Config_Source_Engine</adminhtml_system_config_source_engine>
+                </rewrite>
+            </enterprise_search>
         </models>
         <events>
 


### PR DESCRIPTION
The Enterprise Search module also defines a catalog/search/engine config property in it's system.xml that takes precedence over this module which means users of Enterprise cannot select Algolia from the search engine.  To resolve this a rewrite has been added to ensure Algolia's frontend model is used
@jonpday Can you please review and merge?
